### PR TITLE
brew style --fix Formula/sendkeys.rb

### DIFF
--- a/Formula/sendkeys.rb
+++ b/Formula/sendkeys.rb
@@ -1,18 +1,15 @@
 class Sendkeys < Formula
-  desc "Command line tool for automating keystrokes and mouse events"
+  desc "Command-line tool for automating keystrokes and mouse events"
   homepage "https://github.com/socsieng/sendkeys"
-  url "https://github.com/socsieng/sendkeys.git", :tag => "v2.4.0", :revision => "69f8c7718797c5dbb3323f5562624ddeecf7f300"
+  url "https://github.com/socsieng/sendkeys.git", tag: "v2.4.0", revision: "69f8c7718797c5dbb3323f5562624ddeecf7f300"
   version "2.4.0"
   license "Apache-2.0"
 
-  depends_on :xcode => ["12.0", :build]
-
-  def install
-    system "make", "install", "prefix=#{prefix}"
-  end
-
-  test do
-    system "sendkeys" "--help"
+  bottle do
+    root_url "https://github.com/socsieng/sendkeys/releases/download/v2.4.0"
+    sha256 cellar: :any_skip_relocation, arm64_big_sur: "8b44362905ced4a8988a6292ad1fdb4749c901d90d6953b2becd57013ccc88b4"
+    sha256 cellar: :any_skip_relocation, catalina:      "2678d90af53756fbbc072c73e3df6a2cfcc0ee7ad5da3a261bc1d21f3408ca27"
+    sha256 cellar: :any_skip_relocation, big_sur:       "111b1b8e772a0d91650beb1762d0092ae27efec89255debb7125efb3d1d74e4e"
   end
 
   pour_bottle? do
@@ -20,11 +17,13 @@ class Sendkeys < Formula
     satisfy { true }
   end
 
-  bottle do
-    root_url "https://github.com/socsieng/sendkeys/releases/download/v2.4.0"
-    cellar :any_skip_relocation
-    sha256 "2678d90af53756fbbc072c73e3df6a2cfcc0ee7ad5da3a261bc1d21f3408ca27" => :catalina
-    sha256 "111b1b8e772a0d91650beb1762d0092ae27efec89255debb7125efb3d1d74e4e" => :big_sur
-    sha256 "8b44362905ced4a8988a6292ad1fdb4749c901d90d6953b2becd57013ccc88b4" => :arm64_big_sur
+  depends_on xcode: ["12.0", :build]
+
+  def install
+    system "make", "install", "prefix=#{prefix}"
+  end
+
+  test do
+    system "sendkeys" "--help"
   end
 end


### PR DESCRIPTION
One issue remains:

```
Formula/sendkeys.rb:27:12: W: Combine "sendkeys" and "--help" into a single string literal,
rather than using implicit string concatenation. Or, if they were intended to be separate
method arguments, separate them with a comma.
    system "sendkeys" "--help"
           ^^^^^^^^^^^^^^^^^^^

1 file inspected, 1 offense detected
```